### PR TITLE
Fix a bug in Bytes()

### DIFF
--- a/ring_buffer.go
+++ b/ring_buffer.go
@@ -106,7 +106,7 @@ func (r *RingBuffer) Write(p []byte) (n int, err error) {
 		return 0, nil
 	}
 	r.mu.Lock()
-	if r.w == r.r && r.isFull {
+	if r.isFull {
 		r.mu.Unlock()
 		return 0, ErrIsFull
 	}
@@ -231,7 +231,8 @@ func (r *RingBuffer) Bytes() []byte {
 	if r.w == r.r {
 		if r.isFull {
 			buf := make([]byte, r.size)
-			copy(buf, r.buf)
+			copy(buf, r.buf[r.r:])
+			copy(buf[r.size-r.r:], r.buf[:r.w])
 			return buf
 		}
 		return nil

--- a/ring_buffer_test.go
+++ b/ring_buffer_test.go
@@ -170,6 +170,33 @@ func TestRingBuffer_Write(t *testing.T) {
 	if bytes.Compare(rb.Bytes(), []byte("bcd"+strings.Repeat("abcd", 15))) != 0 {
 		t.Fatalf("expect 63 ... but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
 	}
+
+	rb.Reset()
+	n, err = rb.Write([]byte(strings.Repeat("abcd", 16)))
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if n != 64 {
+		t.Fatalf("expect write 64 bytes but got %d", n)
+	}
+	if rb.Free() != 0 {
+		t.Fatalf("expect free 0 bytes but got %d. r.w=%d, r.r=%d", rb.Free(), rb.w, rb.r)
+	}
+	buf = make([]byte, 16)
+	rb.Read(buf)
+	n, err = rb.Write([]byte(strings.Repeat("1234", 4)))
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if n != 16 {
+		t.Fatalf("expect write 16 bytes but got %d", n)
+	}
+	if rb.Free() != 0 {
+		t.Fatalf("expect free 0 bytes but got %d. r.w=%d, r.r=%d", rb.Free(), rb.w, rb.r)
+	}
+	if !bytes.Equal(append(buf, rb.Bytes()...), []byte(strings.Repeat("abcd", 16)+strings.Repeat("1234", 4))) {
+		t.Fatalf("expect 16 abcd and 4 1234 but got %s. r.w=%d, r.r=%d", rb.Bytes(), rb.w, rb.r)
+	}
 }
 
 func TestRingBuffer_Read(t *testing.T) {


### PR DESCRIPTION
调用 `ringbuffer.Bytes()` 的时候，如果 buffer 是满的，也就是 `r.w == r.r`，copy `r.buf` 的顺序不应该是 0 -> r.size，因为 r.r 和 r.w 此时未必等于 0，所以 copy 的范围应该是先 0 -> r.size，然后 0 -> r.w，否则的话返回的数据的顺序是乱的。