### PR TITLE
dont enter readCond.wait if r.err != nil

### DIFF
--- a/ring_buffer.go
+++ b/ring_buffer.go
@@ -269,6 +269,9 @@ func (r *RingBuffer) Write(p []byte) (n int, err error) {
 		err = r.setErr(err, true)
 		if r.block && (err == ErrIsFull || err == ErrTooMuchDataToWrite) {
 			r.writeCond.Broadcast()
+			if r.err != nil {
+				break
+			}
 			r.readCond.Wait()
 			p = p[n:]
 			err = nil
@@ -396,6 +399,9 @@ func (r *RingBuffer) TryWriteByte(c byte) error {
 }
 
 func (r *RingBuffer) writeByte(c byte) error {
+	if r.err != nil {
+		return r.err
+	}
 	if r.w == r.r && r.isFull {
 		return ErrIsFull
 	}


### PR DESCRIPTION
Goroutine A calls Write, and when the buffer is full, it enters a waiting state. At this point, another goroutine calls CloseWriter.

Normally, one would expect goroutine A to exit the waiting state upon CloseWriter being called. However, in this scenario, even though goroutine A may initially exit the wait due to CloseWriter, if the subsequent call to r.write(p) still returns ErrIsFull (indicating that the buffer remains full or the Write operation cannot proceed for some reason), goroutine A will re-enter r.readCond.Wait(), effectively preventing it from exiting.