### PR TITLE
Reduce timeout allocs and simplify

### DIFF
--- a/ring_buffer_test.go
+++ b/ring_buffer_test.go
@@ -1320,6 +1320,15 @@ func TestWithDeadline(t *testing.T) {
 				}
 			}
 		})
+		t.Run(fmt.Sprint("allocs-test-", i), func(t *testing.T) {
+			timedOut := make(chan error)
+			a := testing.AllocsPerRun(5, func() {
+				rb.Reset()
+				go tests[i].t(timedOut)
+				<-timedOut
+			})
+			t.Logf("Allocs: %f", a)
+		})
 	}
 }
 


### PR DESCRIPTION
Reduce timeout alloc count by ~3~ 4 for all timeout operations. No waiting for unlock from another goroutine.

Great simplification my @lukechampine - all credit goes to him.

Since concurrent reads/writes doesn't make sense here we do not have to worry about an extra broadcast.

Missing a broadcast is expected and ok, since we can't expect readers/writers to always be blocking anyway.