### PR TITLE
Better error handling in ReadFrom() and WriteTo()

### DIFF
--- a/ring_buffer.go
+++ b/ring_buffer.go
@@ -428,7 +428,7 @@ func (r *RingBuffer) ReadFrom(rd io.Reader) (n int64, err error) {
 		nr, rerr := rd.Read(toRead)
 		r.mu.Lock()
 		if rerr != nil && rerr != io.EOF {
-			err = r.setErr(err, true)
+			err = r.setErr(rerr, true)
 			break
 		}
 		if nr == 0 && rerr == nil {
@@ -500,6 +500,7 @@ func (r *RingBuffer) WriteTo(w io.Writer) (n int64, err error) {
 		nr, werr := w.Write(toWrite)
 		r.mu.Lock()
 		if werr != nil {
+			n += int64(nr)
 			err = r.setErr(werr, true)
 			break
 		}


### PR DESCRIPTION
This PR will:

- fix a minor type in ReadFrom(), ensuring the read error is propagated to the caller.
- change WriteTo() to always report the number of bytes written even when an error occurs.
- add tests for the above.